### PR TITLE
video control with gesture

### DIFF
--- a/src/combine_all_test/content.js
+++ b/src/combine_all_test/content.js
@@ -1,33 +1,35 @@
 let videoControlActive = true; // flag to track if video control is active
 
-document.addEventListener('keydown', function(event) {
+function video_change() {
     let video = document.querySelector('video');
 
     if (isGestureMode && video) { // only allow video control when active
-        if (event.key === 'p') { // play/pause
+        if (gesture_var == 1) { // play/pause
             if (video.paused) {
                 video.play();
             } else {
                 video.pause();
             }
         }
-        if (event.key === 's') {
-            video.currentTime += 10; // time+10
+        if (gesture_var == 3) {
+            video.currentTime += (10/3); // time+10
         }
-        if (event.key === 'b') {
-            video.currentTime -= 10; // time-10
+        if (gesture_var == 2) {
+            video.currentTime -= (10/3); // time-10
         }
-        if (event.key === 'n') {
+        if (gesture_var == 5) {
             let nextButton = document.querySelector('.ytp-next-button, .button-nfnext, .skip__button, .next-episode-button, .next-up-card, .player-controls__next');
             if (nextButton) {
                 nextButton.click(); // to next video
             }
         }
-        if (event.key === 'v') {
+        if (gesture_var == 4) {
             let prevButton = document.querySelector('.ytp-prev-button, .button-nfprev, .prev-button, .previous-episode-button, .player-controls__previous');
             if (prevButton) {
                 prevButton.click(); // to previous video
             }
         }
     }
-});
+}
+
+const intervalId3 = setInterval(video_change, 100);

--- a/src/combine_all_test/server.py
+++ b/src/combine_all_test/server.py
@@ -147,6 +147,9 @@ async def websocket_endpoint(websocket: WebSocket):
                 if gesture_counter >= 2:
                     await websocket.send_text(gesture)
                     # print(gesture)
+                    gesture = 0
+                    previous_gesture = 0
+                    gesture_counter = 0
                 else:
                     await websocket.send_text('0')
                     # print('0')


### PR DESCRIPTION
the gesture can now control video. hand open -> pause/play, thumb to right -> forward 10 second, thumb to left -> backward 10 second, finger to right -> next video, finger to left -> previous video. 